### PR TITLE
Small fixes

### DIFF
--- a/modules/quality_tools.py
+++ b/modules/quality_tools.py
@@ -164,7 +164,12 @@ class quality_tools(object):
                         # ----------------------------
                         # sort datasets by InstanceNumber, ImagePositionPatient, SliceLocation, AcquisitionTime, SOPInstanceUID
                         # ----------------------------
-                        dicom_files.sort(key=get_sort_key)
+                        try:
+                            dicom_files.sort(key=get_sort_key)
+                        except AttributeError as error:
+                            log.warning("No sort key found when sorting DICOM files; most likely no SOPInstanceUID. Skipping this scan.")
+                            log.warning(error)
+                            dicom_files = []
                         #log.debug(f'DICOM files sorted ({len(dicom_files)})')
 
                         # ----------------------------
@@ -227,7 +232,11 @@ class quality_tools(object):
         dataset = None
         with scan_file.open() as dicom_file:
 
-            dataset = dicom.dcmread(dicom_file, stop_before_pixels=exclude_pixels)
+            try:
+                dataset = dicom.dcmread(dicom_file, stop_before_pixels=exclude_pixels)
+            except dicom.errors.InvalidDicomError:
+                print("WARNING: InvalidDicomError: Forcing pydicom.dcmread")
+                dataset = dicom.dcmread(dicom_file, stop_before_pixels=exclude_pixels, force=True)
 
         return [scan_file, dataset]
 

--- a/modules/quality_tools.py
+++ b/modules/quality_tools.py
@@ -118,10 +118,17 @@ class quality_tools(object):
                 if args['reset'] == True or not edit_scan.scan_quality or not edit_scan.scan_acquisition:
 
                     # get xnat scan element
-                    xnat_scan = xtools.get_xnat_element(edit_scan.project_id, edit_scan.subject_id, edit_scan.experiment_id, edit_scan.scan_id)
+                    try:
+                        xnat_scan = xtools.get_xnat_element(edit_scan.project_id, edit_scan.subject_id, edit_scan.experiment_id, edit_scan.scan_id)
+                        # get dicom files
+                        scan_files = xnat_scan.resources['DICOM'].files if 'DICOM' in xnat_scan.resources else None                    
+                    except KeyError as exc:
+                        log.warning("Cannot find subject from the database on XNAT; skipping subject.")
+                        log.info(exc)
+                        scan_files = None
+                        
+                        
 
-                    # get dicom files
-                    scan_files = xnat_scan.resources['DICOM'].files if 'DICOM' in xnat_scan.resources else None                    
                     dicom_files = []
                     filtered_dicom_files = []
                     

--- a/modules/xnat_tools.py
+++ b/modules/xnat_tools.py
@@ -13,7 +13,8 @@ class xnat_tools(object):
 
     def __init__(self, xnat_server, xnat_user, xnat_password):
         
-        self.xnat_session = xnat.connect(server=xnat_server, user=xnat_user, password=xnat_password)
+        self.xnat_session = xnat.connect(server=xnat_server, user=xnat_user, password=xnat_password,
+                                         default_timeout=3600)
 
     # ----------------------------
     # xnat server functions
@@ -73,7 +74,7 @@ class xnat_tools(object):
                 log.info('Bypassing create_resource error')
             resource = scan.resources['QC']
   
-        resource.upload(temp_file_path, f'{json_name}.json')
+        resource.upload(temp_file_path, f'{json_name}.json', overwrite=True)
         
         if os.path.exists(temp_dir_path):
             shutil.rmtree(temp_dir_path)


### PR DESCRIPTION
- Some DICOMs were not properly formatted, so I set `force=True` in dicom.dcmread().
- If there are entries in the database, that are no longer on XNAT, it would give an error. I put a try-except around it.
- The script now overwrite JSONs that are already present on XNAT.